### PR TITLE
Fixes required to actually redirect traffic from host and containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ environment variables:
 
 #### Forward all outbound traffic to `127.0.0.1:8080`:
 ```
-docker run --cap-add=NET_ADMIN iptables-redirector
+docker run --cap-add=NET_ADMIN --net=host iptables-redirector
 ```
 
 #### Forward all outbound traffic to `10.0.0.1:3128`:
 ```
 docker run --cap-add=NET_ADMIN \
+  --net=host \
   -e TARGET_IP=10.0.0.1 -e TARGET_PORT=3128 \
   iptables-redirector
 ```
@@ -25,6 +26,7 @@ docker run --cap-add=NET_ADMIN \
 #### Forward traffic destined to `bbc.co.uk` to `127.0.0.1:8080`:
 ```
 docker run --cap-add=NET_ADMIN \
+  --net=host
   -e DESTINATIONS=bbc.co.uk \
   iptables-redirector
 ```
@@ -32,6 +34,7 @@ docker run --cap-add=NET_ADMIN \
 #### Forward traffic destined to `bbc.co.uk` & `google.com` to `127.0.0.1:8080`:
 ```
 docker run --cap-add=NET_ADMIN \
+  --net=host \
   -e DESTINATIONS=bbc.co.uk,google.com \
   iptables-redirector
 ```

--- a/run.sh
+++ b/run.sh
@@ -5,10 +5,12 @@ TARGET_PORT=${TARGET_PORT:-8080}
 
 if [ -z "${DESTINATIONS}" ]; then
   iptables -t nat -A OUTPUT -p tcp -j DNAT --to-destination ${TARGET_IP}:${TARGET_PORT}
+  iptables -t nat -A PREROUTING -p tcp -j DNAT --to-destination ${TARGET_IP}:${TARGET_PORT}
 else
   DESTINATIONS="${DESTINATIONS}" IFS=,
   for dest in $DESTINATIONS; do
     iptables -t nat -A OUTPUT -p tcp -d $dest -j DNAT --to-destination ${TARGET_IP}:${TARGET_PORT}
+    iptables -t nat -A PREROUTING -p tcp -d $dest -j DNAT --to-destination ${TARGET_IP}:${TARGET_PORT}
   done
 fi
 


### PR DESCRIPTION
Hi, thanks for sharing this 👍 

I have recently used docker-iptables-redirector for redirecting traffic from host/docker containers whose destination is `169.254.169.254`(AWS/GCP Metadata service endpoint) to another container([aws-mock-metadata](https://github.com/jtblin/aws-mock-metadata)).
I'm assuming this kind of use-case is pretty common so we'd be happy if it is supported out of box.

I had to do two things to make it work (for me):

(1) pass `--net=host` to the docker container running iptables-redirector for changes made to iptables by the redirector actually take effect on the host
(2) Adding rules to not only OUTPUT chain but also PREROUTING chain. Rules in OUTPUT chain seems to redirect traffic from host but not from containers. If you want to redirect traffic from containers (which I assume is a pretty common use-case) we need to add rules to PREROUTING, too. See https://github.com/jtblin/aws-mock-metadata/pull/5 

Hence this pull request.

Does this change look appropriate for you?
